### PR TITLE
Correção do link da base de dados com o backend.

### DIFF
--- a/EventUSP/backend/build.gradle.kts
+++ b/EventUSP/backend/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
     implementation("org.jetbrains.exposed:exposed-java-time:$exposedVersion")
 
-    // MySQL Database - Usando o conector mais estável para MySQL 8
+    // MySQL Database - Usando o conector mais estável para MySQL   8
     implementation("com.mysql:mysql-connector-j:$mysqlVersion")
 
     // H2 Database (keeping for development/testing)

--- a/EventUSP/backend/src/main/kotlin/Application.kt
+++ b/EventUSP/backend/src/main/kotlin/Application.kt
@@ -5,10 +5,13 @@ import io.ktor.server.application.*
 
 fun main(args: Array<String>) {
     io.ktor.server.netty.EngineMain.main(args)
+    // Testa se a base de dados consegue ser configurada
+    DatabaseConfig.init()
 }
 
 fun Application.module() {
     configureHTTP()
+
     // Inicializa o banco de dados
     DatabaseConfig.init()
 

--- a/EventUSP/backend/src/main/kotlin/config/DatabaseConfig.kt
+++ b/EventUSP/backend/src/main/kotlin/config/DatabaseConfig.kt
@@ -7,6 +7,8 @@ import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.transactions.transaction
 import br.usp.eventUSP.database.tables.*
 import io.ktor.server.config.*
+import org.jetbrains.exposed.sql.StdOutSqlLogger
+import org.jetbrains.exposed.sql.addLogger
 
 /**
  * Configuração do banco de dados MySQL para o sistema EventUSP
@@ -16,6 +18,7 @@ object DatabaseConfig {
      * Inicializa a conexão com o banco de dados e cria as tabelas necessárias
      */
     fun init() {
+        println("Iniciando configuração do banco de dados...")
         // Configura o HikariCP para gerenciamento de pool de conexões
         val config = HikariConfig().apply {
             driverClassName = "com.mysql.cj.jdbc.Driver"
@@ -27,13 +30,18 @@ object DatabaseConfig {
             validationTimeout = 3000
             connectionTimeout = 5000
         }
-        
+
         // Conecta ao banco de dados
+        println("Configurando HikariCP...")
         val dataSource = HikariDataSource(config)
+
+        println("Conectando com Exposed...")
         Database.connect(dataSource)
         
         // Cria as tabelas no banco de dados
+        println("Criando tabelas...")
         transaction {
+            addLogger(StdOutSqlLogger) // Adiciona logs SQL no console
             SchemaUtils.create(
                 EventoTable,
                 UsuarioOrganizadorTable,
@@ -43,5 +51,7 @@ object DatabaseConfig {
                 ParticipantesInteressadosTable
             )
         }
+        println("Banco de dados configurado com sucesso.")
     }
+
 }


### PR DESCRIPTION
Agora, é possível rodar o backend com './gradlew run', tendo feito, antes, './gradlew build'.

Signed-off-by: J-Linaris