### PR TITLE
Funcionalidades de criar evento e adicionar imagem ao evento

### DIFF
--- a/EventUSP/backend/build.gradle.kts
+++ b/EventUSP/backend/build.gradle.kts
@@ -54,6 +54,10 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
     implementation("org.jetbrains.exposed:exposed-java-time:$exposedVersion")
 
+    // Para serializar LocalDateTime
+    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.4.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
+
     // MySQL Database - Usando o conector mais estável para MySQL   8
     implementation("com.mysql:mysql-connector-j:$mysqlVersion")
 

--- a/EventUSP/backend/src/main/kotlin/Application.kt
+++ b/EventUSP/backend/src/main/kotlin/Application.kt
@@ -8,8 +8,6 @@ import kotlinx.serialization.json.Json
 
 fun main(args: Array<String>) {
     io.ktor.server.netty.EngineMain.main(args)
-    // Testa se a base de dados consegue ser configurada
-    DatabaseConfig.init()
 }
 
 fun Application.module() {

--- a/EventUSP/backend/src/main/kotlin/ResponseModels.kt
+++ b/EventUSP/backend/src/main/kotlin/ResponseModels.kt
@@ -32,3 +32,9 @@ data class EventoRequest(
     val organizadorId: Long
 )
 
+@Serializable
+data class ImagemRequest(
+    val url: String,
+    val descricao: String? = null,
+    val eventoId: Long
+)

--- a/EventUSP/backend/src/main/kotlin/ResponseModels.kt
+++ b/EventUSP/backend/src/main/kotlin/ResponseModels.kt
@@ -21,3 +21,14 @@ data class LoginResponse<T>(
     val token: String,
     val user: T
 )
+
+@Serializable
+data class EventoRequest(
+    val titulo: String,
+    val descricao: String,
+    val dataHora: String, // Recebe como string (ISO-8601)
+    val localizacao: String,
+    val categoria: String,
+    val organizadorId: Long
+)
+

--- a/EventUSP/backend/src/main/kotlin/Routing.kt
+++ b/EventUSP/backend/src/main/kotlin/Routing.kt
@@ -311,21 +311,21 @@ fun Application.configureRouting() {
                     call.respond(imagem)
                 }
 
-                get("/evento/{eventoId}") {
-                    val eventoId = call.parameters["eventoId"]?.toLongOrNull()
-                        ?: return@get call.respondText("ID de evento inválido", status = HttpStatusCode.BadRequest)
-
-                    val imagens = imagemRepository.findByEvento(eventoId)
-                    call.respond(imagens)
-                }
-
-                get("/evento/{eventoId}/ordenadas") {
-                    val eventoId = call.parameters["eventoId"]?.toLongOrNull()
-                        ?: return@get call.respondText("ID de evento inválido", status = HttpStatusCode.BadRequest)
-
-                    val imagens = imagemRepository.findByEventoOrdenadas(eventoId)
-                    call.respond(imagens)
-                }
+//                get("/evento/{eventoId}") {
+//                    val eventoId = call.parameters["eventoId"]?.toLongOrNull()
+//                        ?: return@get call.respondText("ID de evento inválido", status = HttpStatusCode.BadRequest)
+//
+//                    val imagens = imagemRepository.findByEvento(eventoId)
+//                    call.respond(imagens)
+//                }
+//
+//                get("/evento/{eventoId}/ordenadas") {
+//                    val eventoId = call.parameters["eventoId"]?.toLongOrNull()
+//                        ?: return@get call.respondText("ID de evento inválido", status = HttpStatusCode.BadRequest)
+//
+//                    val imagens = imagemRepository.findByEventoOrdenadas(eventoId)
+//                    call.respond(imagens)
+//                }
 
                 post {
                     val imagem = call.receive<ImagemEvento>()
@@ -433,7 +433,7 @@ fun Application.configureRouting() {
                             "organizador" -> {
                                 // Verificar se o email já está em uso por outro organizador
                                 if (organizadorRepository.findByEmail(email) != null) {
-                                    call.respond(HttpStatusCode.Conflict, mapOf("message" to "Email já está em uso"))
+                                    call.respond(HttpStatusCode.Conflict, mapOf("message" to "Email ${email} já está em uso"))
                                     return@post
                                 }
                                 
@@ -442,15 +442,7 @@ fun Application.configureRouting() {
                                     call.respond(HttpStatusCode.BadRequest, mapOf("message" to "Foto de perfil é obrigatória para organizadores"))
                                     return@post
                                 }
-                                
-                                // Criar organizador
-//                                val organizador = UsuarioOrganizador(
-//                                    id = null,
-//                                    nome = username,
-//                                    email = email,
-//                                    senha = password, // Na implementação real, a senha deve ser hasheada
-//                                    fotoPerfil = profilePhotoPath
-//                                )
+
                                 // Cria organizador
                                 val organizador = UsuarioOrganizador()
                                 organizador.id = null
@@ -473,7 +465,7 @@ fun Application.configureRouting() {
                             "participante" -> {
                                 // Verificar se o email já está em uso por outro participante
                                 if (participanteRepository.findByEmail(email) != null) {
-                                    call.respond(HttpStatusCode.Conflict, mapOf("message" to "Email já está em uso"))
+                                    call.respond(HttpStatusCode.Conflict, mapOf("message" to "Email ${email} já está em uso"))
                                     return@post
                                 }
                                 

--- a/EventUSP/backend/src/main/kotlin/config/DatabaseConfig.kt
+++ b/EventUSP/backend/src/main/kotlin/config/DatabaseConfig.kt
@@ -24,7 +24,7 @@ object DatabaseConfig {
             driverClassName = "com.mysql.cj.jdbc.Driver"
             jdbcUrl = "jdbc:mysql://localhost:3306/eventusp?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true"
             username = "root" // Altere para o seu usuário do MySQL
-            password = "root" // Altere para a sua senha do MySQL
+            password = "Root1234!" // Altere para a sua senha do MySQL
             maximumPoolSize = 10
             connectionTestQuery = "SELECT 1"
             validationTimeout = 3000

--- a/EventUSP/backend/src/main/kotlin/database/dao/EventoDAO.kt
+++ b/EventUSP/backend/src/main/kotlin/database/dao/EventoDAO.kt
@@ -27,7 +27,7 @@ class EventoDAO(id: EntityID<Long>) : LongEntity(id) {
     val participantesInteressados by UsuarioParticipanteDAO via ParticipantesInteressadosTable
     val reviews by ReviewDAO referrersOn ReviewTable.eventoId
     val imagens by ImagemEventoDAO referrersOn ImagemEventoTable.eventoId
-    
+
     /**
      * Converte o DAO para o modelo
      */

--- a/EventUSP/backend/src/main/kotlin/database/dao/ImagemEventoDAO.kt
+++ b/EventUSP/backend/src/main/kotlin/database/dao/ImagemEventoDAO.kt
@@ -12,7 +12,8 @@ import org.jetbrains.exposed.dao.id.EntityID
 class ImagemEventoDAO(id: EntityID<Long>) : LongEntity(id) {
     companion object : LongEntityClass<ImagemEventoDAO>(ImagemEventoTable)
     
-//    var evento by EventoDAO referencedOn ImagemEventoTable.eventoId
+   // var evento by EventoDAO referencedOn ImagemEventoTable.eventoId
+    var eventoId by ImagemEventoTable.eventoId
     var url by ImagemEventoTable.url
     var descricao by ImagemEventoTable.descricao
     var ordem by ImagemEventoTable.ordem
@@ -23,7 +24,8 @@ class ImagemEventoDAO(id: EntityID<Long>) : LongEntity(id) {
     fun toModel(): ImagemEvento {
         return ImagemEvento(
             id = id.value,
-//            evento = evento.toModel(),
+            eventoId = eventoId.value,
+          //  eventoId = evento.id.value,
             url = url,
             descricao = descricao,
             ordem = ordem

--- a/EventUSP/backend/src/main/kotlin/database/dao/ImagemEventoDAO.kt
+++ b/EventUSP/backend/src/main/kotlin/database/dao/ImagemEventoDAO.kt
@@ -12,7 +12,7 @@ import org.jetbrains.exposed.dao.id.EntityID
 class ImagemEventoDAO(id: EntityID<Long>) : LongEntity(id) {
     companion object : LongEntityClass<ImagemEventoDAO>(ImagemEventoTable)
     
-    var evento by EventoDAO referencedOn ImagemEventoTable.eventoId
+//    var evento by EventoDAO referencedOn ImagemEventoTable.eventoId
     var url by ImagemEventoTable.url
     var descricao by ImagemEventoTable.descricao
     var ordem by ImagemEventoTable.ordem
@@ -23,7 +23,7 @@ class ImagemEventoDAO(id: EntityID<Long>) : LongEntity(id) {
     fun toModel(): ImagemEvento {
         return ImagemEvento(
             id = id.value,
-            evento = evento.toModel(),
+//            evento = evento.toModel(),
             url = url,
             descricao = descricao,
             ordem = ordem

--- a/EventUSP/backend/src/main/kotlin/database/tables/Tables.kt
+++ b/EventUSP/backend/src/main/kotlin/database/tables/Tables.kt
@@ -12,7 +12,6 @@ object EventoTable : LongIdTable("eventos") {
     val descricao = text("descricao")
     val dataHora = datetime("data_hora")
     val localizacao = varchar("localizacao", 255)
-    val imagens = varchar("imagens", 255)
     val categoria = varchar("categoria", 100)
     val organizadorId = reference("organizador_id", UsuarioOrganizadorTable)
     val numeroLikes = integer("numero_likes").default(0)

--- a/EventUSP/backend/src/main/kotlin/database/tables/Tables.kt
+++ b/EventUSP/backend/src/main/kotlin/database/tables/Tables.kt
@@ -25,7 +25,6 @@ object UsuarioOrganizadorTable : LongIdTable("usuarios_organizadores") {
     val email = varchar("email", 255).uniqueIndex()
     val senha = varchar("senha", 255)
     val fotoPerfil = varchar("foto_perfil",255).nullable()
-    // Adicione outros campos conforme necessário
 }
 
 /**
@@ -35,7 +34,6 @@ object UsuarioParticipanteTable : LongIdTable("usuarios_participantes") {
     val nome = varchar("nome", 255)
     val email = varchar("email", 255).uniqueIndex()
     val senha = varchar("senha", 255)
-    // Adicione outros campos conforme necessário
 }
 
 /**

--- a/EventUSP/backend/src/main/kotlin/model/Evento.kt
+++ b/EventUSP/backend/src/main/kotlin/model/Evento.kt
@@ -124,7 +124,6 @@ class Evento(
      */
     fun adicionarImagem(url: String, descricao: String? = null, ordem: Int = imagens.size): ImagemEvento {
         val imagem = ImagemEvento(
-            evento = this,
             url = url,
             descricao = descricao,
             ordem = ordem

--- a/EventUSP/backend/src/main/kotlin/model/Evento.kt
+++ b/EventUSP/backend/src/main/kotlin/model/Evento.kt
@@ -124,6 +124,7 @@ class Evento(
      */
     fun adicionarImagem(url: String, descricao: String? = null, ordem: Int = imagens.size): ImagemEvento {
         val imagem = ImagemEvento(
+            eventoId = this.id!!,
             url = url,
             descricao = descricao,
             ordem = ordem

--- a/EventUSP/backend/src/main/kotlin/model/Evento.kt
+++ b/EventUSP/backend/src/main/kotlin/model/Evento.kt
@@ -1,7 +1,9 @@
 package br.usp.eventUSP.model
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.Contextual
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.UseSerializers
+import br.usp.eventUSP.model.LocalDateTimeSerializer
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 import java.util.*
@@ -14,7 +16,8 @@ class Evento(
     var id: Long? = null,
     var titulo: String,
     var descricao: String,
-    @Contextual var dataHora: LocalDateTime,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    var dataHora: LocalDateTime,
     var localizacao: String,
     var categoria: String,
     var organizador: UsuarioOrganizador

--- a/EventUSP/backend/src/main/kotlin/model/ImagemEvento.kt
+++ b/EventUSP/backend/src/main/kotlin/model/ImagemEvento.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 class ImagemEvento(
     var id: Long? = null,
+    var eventoId: Long,
     var url: String,
     var descricao: String? = null,
     var ordem: Int = 0

--- a/EventUSP/backend/src/main/kotlin/model/ImagemEvento.kt
+++ b/EventUSP/backend/src/main/kotlin/model/ImagemEvento.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 class ImagemEvento(
     var id: Long? = null,
-    var evento: Evento,
     var url: String,
     var descricao: String? = null,
     var ordem: Int = 0
@@ -19,15 +18,11 @@ class ImagemEvento(
             return id == other.id
         }
         
-        return evento == other.evento && url == other.url
+        return url == other.url
     }
     
     override fun hashCode(): Int {
-        var result = id?.hashCode() ?: 0
-        if (result == 0) {
-            result = 31 * result + evento.hashCode()
-            result = 31 * result + url.hashCode()
-        }
+        val result = id?.hashCode() ?: 0
         return result
     }
 }

--- a/EventUSP/backend/src/main/kotlin/model/LocalDateTimeSerializer.kt
+++ b/EventUSP/backend/src/main/kotlin/model/LocalDateTimeSerializer.kt
@@ -1,0 +1,22 @@
+package br.usp.eventUSP.model
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.time.LocalDateTime
+
+object LocalDateTimeSerializer : KSerializer<LocalDateTime> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: LocalDateTime) {
+        encoder.encodeString(value.toString()) // ISO-8601 por padrão
+    }
+
+    override fun deserialize(decoder: Decoder): LocalDateTime {
+        return LocalDateTime.parse(decoder.decodeString())
+    }
+}

--- a/EventUSP/backend/src/main/kotlin/model/UsuarioOrganizador.kt
+++ b/EventUSP/backend/src/main/kotlin/model/UsuarioOrganizador.kt
@@ -1,6 +1,7 @@
 package br.usp.eventUSP.model
 
 import kotlinx.serialization.Serializable
+import java.time.LocalDateTime
 
 /**
  * Classe que representa um usuário organizador no sistema EventUSP
@@ -29,7 +30,7 @@ class UsuarioOrganizador(
     fun criarEvento(
         titulo: String,
         descricao: String,
-        dataHora: java.time.LocalDateTime,
+        dataHora: LocalDateTime,
         localizacao: String,
         categoria: String
             ): Evento {

--- a/EventUSP/backend/src/main/kotlin/repository/EventoRepository.kt
+++ b/EventUSP/backend/src/main/kotlin/repository/EventoRepository.kt
@@ -49,7 +49,7 @@ class EventoRepository {
         // Adiciona as imagens do evento
         evento.imagens.forEach { imagem ->
             ImagemEventoDAO.new {
-              //  this.evento = eventoDAO
+                eventoId = eventoDAO.id
                 url = imagem.url
                 descricao = imagem.descricao
                 ordem = imagem.ordem

--- a/EventUSP/backend/src/main/kotlin/repository/EventoRepository.kt
+++ b/EventUSP/backend/src/main/kotlin/repository/EventoRepository.kt
@@ -49,7 +49,7 @@ class EventoRepository {
         // Adiciona as imagens do evento
         evento.imagens.forEach { imagem ->
             ImagemEventoDAO.new {
-                this.evento = eventoDAO
+              //  this.evento = eventoDAO
                 url = imagem.url
                 descricao = imagem.descricao
                 ordem = imagem.ordem

--- a/EventUSP/backend/src/main/kotlin/repository/ImagemEventoRepository.kt
+++ b/EventUSP/backend/src/main/kotlin/repository/ImagemEventoRepository.kt
@@ -16,11 +16,11 @@ class ImagemEventoRepository {
      * @return A imagem de evento criada com o ID gerado
      */
     fun create(imagem: ImagemEvento): ImagemEvento = transaction {
-        val eventoDAO = EventoDAO.findById(imagem.evento.id!!)
-            ?: throw IllegalArgumentException("Evento não encontrado")
+    //    val eventoDAO = EventoDAO.findById(imagem.eventoId!!)
+     //       ?: throw IllegalArgumentException("Evento não encontrado")
 
         val imagemDAO = ImagemEventoDAO.new {
-            evento = eventoDAO
+        //    evento = eventoDAO
             url = imagem.url
             descricao = imagem.descricao
             ordem = imagem.ordem
@@ -38,26 +38,26 @@ class ImagemEventoRepository {
         ImagemEventoDAO.findById(id)?.toModel()
     }
 
-    /**
-     * Busca todas as imagens de um evento
-     * @param eventoId O ID do evento
-     * @return Lista de imagens do evento
-     */
-    fun findByEvento(eventoId: Long): List<ImagemEvento> = transaction {
-        ImagemEventoDAO.find { br.usp.eventUSP.database.tables.ImagemEventoTable.eventoId eq eventoId }
-            .map { it.toModel() }
-    }
+//    /**
+//     * Busca todas as imagens de um evento
+//     * @param eventoId O ID do evento
+//     * @return Lista de imagens do evento
+//     */
+//    fun findByEvento(eventoId: Long): List<ImagemEvento> = transaction {
+//        ImagemEventoDAO.find { br.usp.eventUSP.database.tables.ImagemEventoTable.eventoId eq eventoId }
+//            .map { it.toModel() }
+//    }
 
-    /**
-     * Busca todas as imagens de um evento ordenadas
-     * @param eventoId O ID do evento
-     * @return Lista de imagens do evento ordenadas pelo campo ordem
-     */
-    fun findByEventoOrdenadas(eventoId: Long): List<ImagemEvento> = transaction {
-        ImagemEventoDAO.find { br.usp.eventUSP.database.tables.ImagemEventoTable.eventoId eq eventoId }
-            .orderBy(br.usp.eventUSP.database.tables.ImagemEventoTable.ordem to SortOrder.ASC)
-            .map { it.toModel() }
-    }
+//    /**
+//     * Busca todas as imagens de um evento ordenadas
+//     * @param eventoId O ID do evento
+//     * @return Lista de imagens do evento ordenadas pelo campo ordem
+//     */
+//    fun findByEventoOrdenadas(eventoId: Long): List<ImagemEvento> = transaction {
+//        ImagemEventoDAO.find { br.usp.eventUSP.database.tables.ImagemEventoTable.eventoId eq eventoId }
+//            .orderBy(br.usp.eventUSP.database.tables.ImagemEventoTable.ordem to SortOrder.ASC)
+//            .map { it.toModel() }
+//    }
 
     /**
      * Busca todas as imagens de eventos

--- a/EventUSP/backend/src/main/kotlin/repository/ImagemEventoRepository.kt
+++ b/EventUSP/backend/src/main/kotlin/repository/ImagemEventoRepository.kt
@@ -16,11 +16,11 @@ class ImagemEventoRepository {
      * @return A imagem de evento criada com o ID gerado
      */
     fun create(imagem: ImagemEvento): ImagemEvento = transaction {
-    //    val eventoDAO = EventoDAO.findById(imagem.eventoId!!)
-     //       ?: throw IllegalArgumentException("Evento não encontrado")
+        val eventoNoDAO = EventoDAO.findById(imagem.eventoId)
+            ?: throw IllegalArgumentException("Evento não encontrado")
 
         val imagemDAO = ImagemEventoDAO.new {
-        //    evento = eventoDAO
+            eventoId = eventoNoDAO.id
             url = imagem.url
             descricao = imagem.descricao
             ordem = imagem.ordem
@@ -38,26 +38,26 @@ class ImagemEventoRepository {
         ImagemEventoDAO.findById(id)?.toModel()
     }
 
-//    /**
-//     * Busca todas as imagens de um evento
-//     * @param eventoId O ID do evento
-//     * @return Lista de imagens do evento
-//     */
-//    fun findByEvento(eventoId: Long): List<ImagemEvento> = transaction {
-//        ImagemEventoDAO.find { br.usp.eventUSP.database.tables.ImagemEventoTable.eventoId eq eventoId }
-//            .map { it.toModel() }
-//    }
+    /**
+     * Busca todas as imagens de um evento
+     * @param eventoId O ID do evento
+     * @return Lista de imagens do evento
+     */
+    fun findByEvento(eventoId: Long): List<ImagemEvento> = transaction {
+        ImagemEventoDAO.find { br.usp.eventUSP.database.tables.ImagemEventoTable.eventoId eq eventoId }
+            .map { it.toModel() }
+    }
 
-//    /**
-//     * Busca todas as imagens de um evento ordenadas
-//     * @param eventoId O ID do evento
-//     * @return Lista de imagens do evento ordenadas pelo campo ordem
-//     */
-//    fun findByEventoOrdenadas(eventoId: Long): List<ImagemEvento> = transaction {
-//        ImagemEventoDAO.find { br.usp.eventUSP.database.tables.ImagemEventoTable.eventoId eq eventoId }
-//            .orderBy(br.usp.eventUSP.database.tables.ImagemEventoTable.ordem to SortOrder.ASC)
-//            .map { it.toModel() }
-//    }
+    /**
+     * Busca todas as imagens de um evento ordenadas
+     * @param eventoId O ID do evento
+     * @return Lista de imagens do evento ordenadas pelo campo ordem
+     */
+    fun findByEventoOrdenadas(eventoId: Long): List<ImagemEvento> = transaction {
+        ImagemEventoDAO.find { br.usp.eventUSP.database.tables.ImagemEventoTable.eventoId eq eventoId }
+            .orderBy(br.usp.eventUSP.database.tables.ImagemEventoTable.ordem to SortOrder.ASC)
+            .map { it.toModel() }
+    }
 
     /**
      * Busca todas as imagens de eventos

--- a/EventUSP/backend/src/test/kotlin/model/EventoRouteTest.kt
+++ b/EventUSP/backend/src/test/kotlin/model/EventoRouteTest.kt
@@ -1,0 +1,141 @@
+package model
+
+import br.usp.eventUSP.configureRouting
+import br.usp.eventUSP.database.tables.EventoTable
+import br.usp.eventUSP.database.tables.ImagemEventoTable
+import br.usp.eventUSP.database.tables.UsuarioOrganizadorTable
+import br.usp.eventUSP.database.tables.UsuarioParticipanteTable
+import br.usp.eventUSP.model.Evento
+import br.usp.eventUSP.repository.EventoRepository
+import br.usp.eventUSP.repository.UsuarioOrganizadorRepository
+import br.usp.eventUSP.EventoRequest
+import br.usp.eventUSP.UserResponse
+import br.usp.eventUSP.model.UsuarioOrganizador
+import br.usp.eventUSP.model.UsuarioParticipante
+import io.ktor.server.testing.*
+import io.ktor.client.request.*
+import io.ktor.client.request.forms.formData
+import io.ktor.client.request.forms.submitFormWithBinaryData
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.junit.jupiter.api.*
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import java.time.LocalDateTime
+import kotlin.io.readBytes
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class EventoRouteTest {
+
+    @BeforeAll
+    fun setupDb() {
+        Database.Companion.connect(
+            "jdbc:h2:mem:test-evento;DB_CLOSE_DELAY=-1;",
+            driver = "org.h2.Driver"
+        )
+        transaction {
+            SchemaUtils.create(
+                ImagemEventoTable,
+                EventoTable,
+                UsuarioParticipanteTable,
+                UsuarioOrganizadorTable,
+                // adicione outras tabelas que o evento utiliza, caso necessário
+            )
+        }
+    }
+
+    @BeforeEach
+    fun cleanDb() {
+        transaction {
+            ImagemEventoTable.deleteAll()
+            EventoTable.deleteAll()
+            UsuarioParticipanteTable.deleteAll()
+            UsuarioOrganizadorTable.deleteAll()
+
+            // limpe outras tabelas relacionadas aqui
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    fun `deve criar um evento e retornar corretamente`() {
+
+        val json = Json { ignoreUnknownKeys = true }
+
+        testApplication {
+            application { configureRouting() }
+
+            // Cria organizador usando multipart/form-data
+            val createResponse = client.submitFormWithBinaryData(
+                url = "/api/users/register",
+                formData = formData {
+                    append("email", "org3@usp.br")
+                    append("username", "Organizador Que Cria Evento")
+                    append("password", "orgpass")
+                    append("accountType", "organizador")
+                    val arquivoFoto = File("src/test/kotlin/bemvindomessi.jpeg")
+                    append(
+                        "profilePhoto",
+                        arquivoFoto.readBytes(),
+                        Headers.build {
+                            append(HttpHeaders.ContentType, "image/jpeg")
+                            append(HttpHeaders.ContentDisposition, "filename=\"bemvindomessi.jpg\"")
+                        }
+                    )
+                }
+            )
+
+            println(createResponse.status)
+            println(createResponse.bodyAsText())
+            assertEquals(HttpStatusCode.Created, createResponse.status)
+
+            val organizerResponse = json.decodeFromString<UserResponse<UsuarioOrganizador>>(createResponse.bodyAsText())
+            assertEquals("Organizador criado com sucesso", organizerResponse.message)
+            assertEquals("Organizador Que Cria Evento", organizerResponse.user.nome)
+            // assertEquals("https://linkfoto.com/foto.jpg", organizerResponse.user.fotoPerfil)
+            assertNotNull(organizerResponse.token)
+
+            val eventoRequest = EventoRequest(
+                titulo = "Festa de Integração",
+                descricao = "Evento para integração dos alunos",
+                dataHora = LocalDateTime.now().plusDays(3).toString(), // Formato ISO-8601
+                localizacao = "USP Butantã",
+                categoria = "Festa",
+                organizadorId = organizerResponse.user.id!!
+            )
+
+            // Envia requisição para criar evento
+            val response = client.post("/api/eventos/criar") {
+                contentType(ContentType.Application.Json)
+                setBody(json.encodeToString(eventoRequest))
+            }
+
+            println(response.status)
+
+            assertEquals(HttpStatusCode.Companion.Created, response.status)
+
+            // Valida se evento foi criado na resposta
+            val createdEvento = json.decodeFromString<Evento>(response.bodyAsText())
+            assertEquals(eventoRequest.titulo, createdEvento.titulo)
+            assertEquals(eventoRequest.descricao, createdEvento.descricao)
+            assertEquals(eventoRequest.localizacao, createdEvento.localizacao)
+            assertEquals(eventoRequest.organizadorId, createdEvento.organizador.id)
+            // assertEquals(1, createdEvento.imagens.size)
+            // assertEquals("https://link.com/img.jpg", createdEvento.imagens[0].url)
+
+            // Valida se evento foi salvo no banco (repositório)
+            val eventRepo = EventoRepository()
+            val salvo = eventRepo.findById(createdEvento.id!!)
+            assertNotNull(salvo)
+            assertEquals(eventoRequest.titulo, salvo.titulo)
+            assertEquals(eventoRequest.organizadorId, salvo.organizador.id)
+            //   assertTrue(salvo.imagens.any { it.url == "https://link.com/img.jpg" } ?: false)
+        }
+    }
+}

--- a/EventUSP/backend/src/test/kotlin/model/EventoTest.kt
+++ b/EventUSP/backend/src/test/kotlin/model/EventoTest.kt
@@ -138,7 +138,7 @@ class EventoTest {
         )
         
         assertEquals(1, evento.imagens.size)
-     //   assertEquals(evento, imagem.evento)
+        assertEquals(evento.id, imagem.eventoId)
         assertEquals("https://exemplo.com/imagem-adicional.jpg", imagem.url)
         assertEquals("Descrição da imagem", imagem.descricao)
         assertEquals(0, imagem.ordem) // Primeira imagem recebe ordem 0
@@ -188,7 +188,7 @@ class EventoTest {
         )
         
         val imagemDeOutroEvento = ImagemEvento(
-        //    evento = outroEvento,
+            eventoId = outroEvento.id!!,
             url = "https://exemplo.com/imagem-outro-evento.jpg"
         )
         

--- a/EventUSP/backend/src/test/kotlin/model/EventoTest.kt
+++ b/EventUSP/backend/src/test/kotlin/model/EventoTest.kt
@@ -138,7 +138,7 @@ class EventoTest {
         )
         
         assertEquals(1, evento.imagens.size)
-        assertEquals(evento, imagem.evento)
+     //   assertEquals(evento, imagem.evento)
         assertEquals("https://exemplo.com/imagem-adicional.jpg", imagem.url)
         assertEquals("Descrição da imagem", imagem.descricao)
         assertEquals(0, imagem.ordem) // Primeira imagem recebe ordem 0
@@ -188,7 +188,7 @@ class EventoTest {
         )
         
         val imagemDeOutroEvento = ImagemEvento(
-            evento = outroEvento,
+        //    evento = outroEvento,
             url = "https://exemplo.com/imagem-outro-evento.jpg"
         )
         

--- a/EventUSP/backend/src/test/kotlin/model/ImagemEventoTest.kt
+++ b/EventUSP/backend/src/test/kotlin/model/ImagemEventoTest.kt
@@ -32,7 +32,7 @@ class ImagemEventoTest {
         
         imagemEvento = ImagemEvento(
             id = 1L,
-         //   evento = evento,
+            eventoId = evento.id!!,
             url = "https://exemplo.com/imagem.jpg",
             descricao = "Foto do palestrante",
             ordem = 1
@@ -45,7 +45,7 @@ class ImagemEventoTest {
     @Test
     fun `deve inicializar imagem evento corretamente`() {
         assertEquals(1L, imagemEvento.id)
-     //   assertEquals(evento, imagemEvento.evento)
+        assertEquals(evento.id, imagemEvento.eventoId)
         assertEquals("https://exemplo.com/imagem.jpg", imagemEvento.url)
         assertEquals("Foto do palestrante", imagemEvento.descricao)
         assertEquals(1, imagemEvento.ordem)
@@ -54,12 +54,12 @@ class ImagemEventoTest {
     @Test
     fun `deve inicializar imagem evento com valores padrão`() {
         val imagemSemDescricao = ImagemEvento(
-         //   evento = evento,
+            eventoId = evento.id!!,
             url = "https://exemplo.com/outra-imagem.jpg"
         )
         
         assertNull(imagemSemDescricao.id)
-       // assertEquals(evento, imagemSemDescricao.evento)
+        assertEquals(evento.id, imagemSemDescricao.eventoId)
         assertEquals("https://exemplo.com/outra-imagem.jpg", imagemSemDescricao.url)
         assertNull(imagemSemDescricao.descricao)
         assertEquals(0, imagemSemDescricao.ordem)
@@ -106,7 +106,7 @@ class ImagemEventoTest {
     fun `deve comparar imagens evento corretamente pelo id`() {
         val imagemMesmoId = ImagemEvento(
             id = 1L,
-         //   evento = evento,
+            eventoId = evento.id!!,
             url = "https://exemplo.com/outra-url.jpg",
             descricao = "Outra descrição",
             ordem = 2
@@ -114,7 +114,7 @@ class ImagemEventoTest {
         
         val imagemIdDiferente = ImagemEvento(
             id = 2L,
-         //   evento = evento,
+            eventoId = evento.id!!,
             url = imagemEvento.url,
             descricao = imagemEvento.descricao,
             ordem = imagemEvento.ordem
@@ -127,17 +127,17 @@ class ImagemEventoTest {
     @Test
     fun `deve comparar imagens evento pela url quando id for nulo`() {
         val imagemSemId1 = ImagemEvento(
-        //    evento = evento,
+            eventoId = evento.id!!,
             url = "https://exemplo.com/imagem1.jpg"
         )
         
         val imagemSemId2 = ImagemEvento(
-         //   evento = evento,
+            eventoId = evento.id!!,
             url = "https://exemplo.com/imagem1.jpg"
         )
         
         val imagemSemId3 = ImagemEvento(
-         //   evento = evento,
+            eventoId = evento.id!!,
             url = "https://exemplo.com/imagem2.jpg"
         )
         

--- a/EventUSP/backend/src/test/kotlin/model/ImagemEventoTest.kt
+++ b/EventUSP/backend/src/test/kotlin/model/ImagemEventoTest.kt
@@ -32,7 +32,7 @@ class ImagemEventoTest {
         
         imagemEvento = ImagemEvento(
             id = 1L,
-            evento = evento,
+         //   evento = evento,
             url = "https://exemplo.com/imagem.jpg",
             descricao = "Foto do palestrante",
             ordem = 1
@@ -45,7 +45,7 @@ class ImagemEventoTest {
     @Test
     fun `deve inicializar imagem evento corretamente`() {
         assertEquals(1L, imagemEvento.id)
-        assertEquals(evento, imagemEvento.evento)
+     //   assertEquals(evento, imagemEvento.evento)
         assertEquals("https://exemplo.com/imagem.jpg", imagemEvento.url)
         assertEquals("Foto do palestrante", imagemEvento.descricao)
         assertEquals(1, imagemEvento.ordem)
@@ -54,12 +54,12 @@ class ImagemEventoTest {
     @Test
     fun `deve inicializar imagem evento com valores padrão`() {
         val imagemSemDescricao = ImagemEvento(
-            evento = evento,
+         //   evento = evento,
             url = "https://exemplo.com/outra-imagem.jpg"
         )
         
         assertNull(imagemSemDescricao.id)
-        assertEquals(evento, imagemSemDescricao.evento)
+       // assertEquals(evento, imagemSemDescricao.evento)
         assertEquals("https://exemplo.com/outra-imagem.jpg", imagemSemDescricao.url)
         assertNull(imagemSemDescricao.descricao)
         assertEquals(0, imagemSemDescricao.ordem)
@@ -106,7 +106,7 @@ class ImagemEventoTest {
     fun `deve comparar imagens evento corretamente pelo id`() {
         val imagemMesmoId = ImagemEvento(
             id = 1L,
-            evento = evento,
+         //   evento = evento,
             url = "https://exemplo.com/outra-url.jpg",
             descricao = "Outra descrição",
             ordem = 2
@@ -114,7 +114,7 @@ class ImagemEventoTest {
         
         val imagemIdDiferente = ImagemEvento(
             id = 2L,
-            evento = evento,
+         //   evento = evento,
             url = imagemEvento.url,
             descricao = imagemEvento.descricao,
             ordem = imagemEvento.ordem
@@ -127,17 +127,17 @@ class ImagemEventoTest {
     @Test
     fun `deve comparar imagens evento pela url quando id for nulo`() {
         val imagemSemId1 = ImagemEvento(
-            evento = evento,
+        //    evento = evento,
             url = "https://exemplo.com/imagem1.jpg"
         )
         
         val imagemSemId2 = ImagemEvento(
-            evento = evento,
+         //   evento = evento,
             url = "https://exemplo.com/imagem1.jpg"
         )
         
         val imagemSemId3 = ImagemEvento(
-            evento = evento,
+         //   evento = evento,
             url = "https://exemplo.com/imagem2.jpg"
         )
         

--- a/EventUSP/backend/src/test/kotlin/model/LoginRouteTest.kt
+++ b/EventUSP/backend/src/test/kotlin/model/LoginRouteTest.kt
@@ -126,15 +126,16 @@ class LoginRouteTest {
                 append("username", "Organizador Evento")
                 append("password", "orgpass")
                 append("accountType", "organizador")
-                val arquivoFoto = File("src/test/kotlin/bemvindomessi.jpeg")
-                append(
-                    "profilePhoto",
-                    arquivoFoto.readBytes(),
-                    Headers.build {
-                        append(HttpHeaders.ContentType, "image/jpeg")
-                        append(HttpHeaders.ContentDisposition, "filename=\"bemvindomessi.jpg\"")
-                    }
-                )
+//                    val arquivoFoto = File("src/test/kotlin/bemvindomessi.jpeg")
+//                    append(
+//                        "profilePhoto",
+//                        arquivoFoto.readBytes(),
+//                        Headers.build {
+//                            append(HttpHeaders.ContentType, "image/jpeg")
+//                            append(HttpHeaders.ContentDisposition, "filename=\"bemvindomessi.jpg\"")
+//                        }
+//                    )
+                append("profilePhoto","https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSABqV-VQBSF1Qyj1Qyo6RiLfpA0McI1leTvQ&s")
             }
         )
 
@@ -145,7 +146,7 @@ class LoginRouteTest {
         val organizerResponse = json.decodeFromString<UserResponse<UsuarioOrganizador>>(createResponse.bodyAsText())
         assertEquals("Organizador criado com sucesso", organizerResponse.message)
         assertEquals("Organizador Evento", organizerResponse.user.nome)
-       // assertEquals("https://linkfoto.com/foto.jpg", organizerResponse.user.fotoPerfil)
+        assertEquals("https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSABqV-VQBSF1Qyj1Qyo6RiLfpA0McI1leTvQ&s", organizerResponse.user.fotoPerfil)
         assertNotNull(organizerResponse.token)
 
         // Login organizador
@@ -160,7 +161,7 @@ class LoginRouteTest {
         assertEquals("Login efetuado com sucesso!", loginResponse.message)
         assertEquals("Organizador Evento", loginResponse.user.nome)
         assertEquals("org123@usp.br", loginResponse.user.email)
-      //  assertEquals("https://linkfoto.com/foto.jpg", loginResponse.user.fotoPerfil)
+        assertEquals("https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSABqV-VQBSF1Qyj1Qyo6RiLfpA0McI1leTvQ&s", loginResponse.user.fotoPerfil)
     }
 
     @Test

--- a/EventUSP/backend/src/test/kotlin/model/UsuarioOrganizadorTest.kt
+++ b/EventUSP/backend/src/test/kotlin/model/UsuarioOrganizadorTest.kt
@@ -64,7 +64,16 @@ class UsuarioOrganizadorTest {
         
         organizador.eventosOrganizados.add(evento)
     }
-    
+
+    @AfterAll
+    fun tearDownDb() {
+        transaction {
+            SchemaUtils.drop(
+                UsuarioOrganizadorTable
+            )
+        }
+    }
+
     @Test
     fun `deve inicializar organizador corretamente`() {
         assertEquals(1L, organizador.id)
@@ -79,12 +88,6 @@ class UsuarioOrganizadorTest {
     
     @Test
     fun `deve inicializar organizador com valores opcionais nulos`() {
-//        val organizadorSemOpcionais = UsuarioOrganizador(
-//            id = 2L,
-//            nome = "Outro Organizador",
-//            email = "outro@usp.br",
-//            senha = "senha456"
-//        )
         val organizadorSemOpcionais = UsuarioOrganizador()
         organizadorSemOpcionais.id = 2L
         organizadorSemOpcionais.nome = "Outro Organizador"
@@ -131,12 +134,6 @@ class UsuarioOrganizadorTest {
     
     @Test
     fun `não deve cancelar evento de outro organizador`() {
-//        val outroOrganizador = UsuarioOrganizador(
-//            id = 3L,
-//            nome = "Outro Organizador",
-//            email = "outro@usp.br",
-//            senha = "senha789"
-//        )
         val outroOrganizador = UsuarioOrganizador()
         outroOrganizador.id = 3L
         outroOrganizador.nome = "Outro Organizador"
@@ -209,12 +206,6 @@ class UsuarioOrganizadorTest {
     
     @Test
     fun `não deve atualizar evento de outro organizador`() {
-//        val outroOrganizador = UsuarioOrganizador(
-//            id = 3L,
-//            nome = "Outro Organizador",
-//            email = "outro@usp.br",
-//            senha = "senha789"
-//        )
         val outroOrganizador = UsuarioOrganizador()
         outroOrganizador.id = 3L
         outroOrganizador.nome = "Outro Organizador"
@@ -256,7 +247,6 @@ class UsuarioOrganizadorTest {
         assertEquals("https://exemplo.com/imagem-adicional.jpg", imagem?.url)
         assertEquals("Foto do local", imagem?.descricao)
         assertEquals(1, imagem?.ordem)
-        assertEquals(evento, imagem?.evento)
     }
     
     @Test
@@ -273,12 +263,6 @@ class UsuarioOrganizadorTest {
     
     @Test
     fun `não deve adicionar imagem a evento de outro organizador`() {
-//        val outroOrganizador = UsuarioOrganizador(
-//            id = 3L,
-//            nome = "Outro Organizador",
-//            email = "outro@usp.br",
-//            senha = "senha789"
-//        )
         val outroOrganizador = UsuarioOrganizador()
         outroOrganizador.id = 3L
         outroOrganizador.nome = "Outro Organizador"
@@ -320,12 +304,6 @@ class UsuarioOrganizadorTest {
     
     @Test
     fun `não deve remover imagem de evento de outro organizador`() {
-//        val outroOrganizador = UsuarioOrganizador(
-//            id = 3L,
-//            nome = "Outro Organizador",
-//            email = "outro@usp.br",
-//            senha = "senha789"
-//        )
         val outroOrganizador = UsuarioOrganizador()
         outroOrganizador.id = 3L
         outroOrganizador.nome = "Outro Organizador"
@@ -343,7 +321,6 @@ class UsuarioOrganizadorTest {
         )
         
         val imagem = ImagemEvento(
-            evento = eventoDeOutroOrganizador,
             url = "https://exemplo.com/imagem-outro-evento.jpg"
         )
         
@@ -352,24 +329,12 @@ class UsuarioOrganizadorTest {
     
     @Test
     fun `deve comparar organizadores corretamente`() {
-//        val organizadorMesmoId = UsuarioOrganizador(
-//            id = 1L,
-//            nome = "Outro Nome",
-//            email = "outro@usp.br",
-//            senha = "outrasenha"
-//        )
         val organizadorMesmoId = UsuarioOrganizador()
         organizadorMesmoId.id = 1L
         organizadorMesmoId.nome = "Outro Nome"
         organizadorMesmoId.email = "outro@usp.br"
         organizadorMesmoId.senha = "outrasenha"
-        
-//        val organizadorMesmoEmail = UsuarioOrganizador(
-//            id = 100L,
-//            nome = "Outro Nome",
-//            email = "organizador@usp.br",
-//            senha = "outrasenha"
-//        )
+
         val organizadorMesmoEmail = UsuarioOrganizador()
         organizadorMesmoEmail.id = 100L
         organizadorMesmoEmail.nome = "Outro Nome"

--- a/EventUSP/backend/src/test/kotlin/model/UsuarioOrganizadorTest.kt
+++ b/EventUSP/backend/src/test/kotlin/model/UsuarioOrganizadorTest.kt
@@ -87,17 +87,6 @@ class UsuarioOrganizadorTest {
     }
     
     @Test
-    fun `deve inicializar organizador com valores opcionais nulos`() {
-        val organizadorSemOpcionais = UsuarioOrganizador()
-        organizadorSemOpcionais.id = 2L
-        organizadorSemOpcionais.nome = "Outro Organizador"
-        organizadorSemOpcionais.email = "outro@usp.br"
-        organizadorSemOpcionais.senha = "senha456"
-//        organizador.fotoPerfil = "https://exemplo.com/foto-organizador-outro.jpg"
-        assertNull(organizadorSemOpcionais.fotoPerfil)
-    }
-    
-    @Test
     fun `deve atualizar foto de perfil com sucesso`() {
         organizador.atualizarFotoPerfil("https://exemplo.com/nova-foto.jpg")
         assertEquals("https://exemplo.com/nova-foto.jpg", organizador.fotoPerfil)
@@ -321,6 +310,7 @@ class UsuarioOrganizadorTest {
         )
         
         val imagem = ImagemEvento(
+            eventoId = eventoDeOutroOrganizador.id!!,
             url = "https://exemplo.com/imagem-outro-evento.jpg"
         )
         

--- a/EventUSP/backend/src/test/kotlin/model/UsuarioParticipanteTest.kt
+++ b/EventUSP/backend/src/test/kotlin/model/UsuarioParticipanteTest.kt
@@ -78,7 +78,17 @@ class UsuarioParticipanteTest {
             organizador = organizador
         )
     }
-    
+
+    @AfterAll
+    fun tearDownDb() {
+        transaction {
+            SchemaUtils.drop(
+                UsuarioParticipanteTable,
+                UsuarioOrganizadorTable
+            )
+        }
+    }
+
     @Test
     fun `deve inicializar participante com foto de perfil corretamente`() {
         assertEquals(2L, participante.id)


### PR DESCRIPTION
Foram adicionadas as conexões de routing e responsemodels necessárias para criar um evento e também para adicionar uma imagem a ele. O teste EventoRouteTest.kt mostra como fazer essa conexão corretamente e que ela está funcionando. Para adicionar as imagens, foi preciso alterar um pouco da relação entre uma ImagemEvento e um Evento, de forma que os repositórios se comuniquem apropriadamente e o routing consiga ser completo. Mais detalhes nos commits.